### PR TITLE
Top menu: fixes for mobile

### DIFF
--- a/public/javascripts/foundation.min.js
+++ b/public/javascripts/foundation.min.js
@@ -5046,13 +5046,18 @@
           }
         } else if (topbar.parent().hasClass('fixed')) {
           if (settings.scrolltop) {
-            topbar.parent().removeClass('fixed');
+            /**
+			 * CUSTOM RECALBOX
+			 * Avoid remove of fixed class on top bar container
+			 */
+		  	//topbar.parent().removeClass('fixed');
             topbar.addClass('fixed');
             self.S('body').removeClass('f-topbar-fixed');
 
             window.scrollTo(0, 0);
           } else {
-            topbar.parent().removeClass('expanded');
+
+			  topbar.parent().removeClass('expanded');
           }
         }
       } else {

--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -47,12 +47,19 @@ nav.top-bar-recalbox {
 .top-bar-recalbox .top-bar-section li.social-icon-menu:not(.has-form) a:not(.button) {
     line-height: 2.813rem;
 }
+.top-bar-recalbox .top-bar-section .has-dropdown > a::after {
+    top: 2rem;
+}
 
 /* Mobile menu */
 @media only screen and (max-width: 40em) {
     .top-bar-section ul {
         margin: 16px 0px 0px;
     }
+    .top-bar-recalbox .top-bar-section .left {
+        margin-left: 0;
+    }
+
 }
 
 .top-bar.expanded {
@@ -62,6 +69,20 @@ nav.top-bar-recalbox {
     background: #34495E;
     height: 3.813rem;
     line-height: 3.813rem;
+}
+.top-bar-recalbox.expanded .top-bar-section li:hover:not(.has-form):not(.active) > a:not(.button) {
+    color: #FFF;
+    background-color: #50687B;
+}
+.top-bar-recalbox .top-bar-section .dropdown li.title h5 a:hover, .top-bar-section .dropdown li.parent-link a:hover {
+    background-color: #6a8598;
+}
+.top-bar-recalbox .toggle-topbar.menu-icon a {
+    color: #FFF;
+    height: 48px;
+    line-height: 2.813rem;
+    padding: 0px 2.5rem 0px 0.9375rem;
+    position: relative;
 }
 
 

--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -48,6 +48,23 @@ nav.top-bar-recalbox {
     line-height: 2.813rem;
 }
 
+/* Mobile menu */
+@media only screen and (max-width: 40em) {
+    .top-bar-section ul {
+        margin: 16px 0px 0px;
+    }
+}
+
+.top-bar.expanded {
+    background: #34495E;
+}
+.top-bar.expanded .title-area {
+    background: #34495E;
+    height: 3.813rem;
+    line-height: 3.813rem;
+}
+
+
 /* Foundation icons sizes */
 .size-12 { font-size: 12px; }
 .size-14 { font-size: 14px; }

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -25,7 +25,7 @@
 
           <section class="top-bar-section">
               <!-- Right Nav Section -->
-              <ul class="right">
+              <ul class="right hide-for-small-only">
                   <li class="social-icon-menu"><a href="https://twitter.com/digitaLumberjak" target="_blank"><i class="fi-social-twitter size-16"></i></a></li>
                   <li class="social-icon-menu"><a href="https://www.facebook.com/recalbox" target="_blank"><i class="fi-social-google-plus size-16"></i></a></li>
                   <li class="social-icon-menu"><a href="https://www.facebook.com/recalbox" target="_blank"><i class="fi-social-facebook size-16"></i></a></li>


### PR DESCRIPTION
Résoud quelques problèmes pour la version mobile du top menu:

- Couleur de la barre
- Couleur des menus au passage de la souris
- Suppression des social icons (fb, github) qui sont pas super utiles en mobile
- Correction bug de la position du menu en mobile
- Recentre le texte "MENU"
- Recentre la flèche de sous-menu